### PR TITLE
Add info to job card in KOD dashboard

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -5,7 +5,6 @@ form:
     - prot_mode
     - email
 
-
 cluster: "katana"
 
 attributes:
@@ -30,6 +29,9 @@ attributes:
         widget: "text_field"
         label: "Run Name"
         placeholder: "Enter your run name"
+        pattern: '^[A-Za-z0-9_]+$'
+        help: |
+            <a>Alphanumeric and "_" only</a>
 
     af_method:
         widget: "select"
@@ -44,6 +46,7 @@ attributes:
             - ["Alphafold2", "af2", data-hide-mode: false]
             - ["ESMFold", "esmf", data-hide-mode: true]
             - ["RoseTTAFold-All-Atom", "rfaa", data-hide-mode: true]
+        display: true
 
     prot_mode:
         widget: "select"
@@ -51,6 +54,7 @@ attributes:
         options:
             - ["Monomer", "monomer"]
             - ["Multimer", "multimer"]
+        display: true
 
     email:
         widget: "text_field"

--- a/info.html.erb
+++ b/info.html.erb
@@ -1,0 +1,3 @@
+<% if ! connect.user.blank? %>
+<b>Results</b>: <a target="_blank" href="https://kod.restech.unsw.edu.au/pun/sys/dashboard/files/fs/srv/scratch/<%= connect.user %>/proteinfold_output/<%= connect.run_dir %>"><%= connect.run_dir %></a>
+<% end %>

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -2,6 +2,9 @@ batch_connect:
     template: "basic"
     queue_name: "submission"
     script_file: "/srv/scratch/sbf-pipelines/proteinfold/bin/start-alphafold2.sh"
+    conn_params:
+        - run_dir
+        - user
 
 script:
     native:

--- a/template/after.sh.erb
+++ b/template/after.sh.erb
@@ -1,0 +1,7 @@
+RUN_DIR=$(echo "<%= context.run_name %>" | sed "s#[^A-Za-z0-9]#_#g")
+OUT_DIR="/srv/scratch/${USER}/proteinfold_output/${RUN_DIR}"
+
+ln -s $OUT_DIR
+
+export run_dir="$RUN_DIR"
+export user="${USER}"


### PR DESCRIPTION
- Updated form to display method and mode on job card as well as validate job_name.
    - Validation is probably not strictly required but makes it easier to link to result directory and probably also helps the user navigate if they know the exact internal job name.
- Added user and run_dir info to conn_params and exported from after.sh to expose required info to card views.
- Added simple info.html.erb to display link to job output directory on job card.
- Symlinked result directory in KOD session for easier navigation.

Partially addresses #24. Probably need to interface with nextflow outputs to pull in the specific work directories. This can be done later if we want with clean.sh.erb which will run after script execution.

Unfortunately HTML reports will not render in KOD browser - displays as raw html. Some support will be available in OOD 4.1 release. Some discussion [here](https://github.com/OSC/ondemand/issues/1619).

**Note:** empty connection.yml.erb is intentional based on discussion from [here](https://discourse.openondemand.org/t/how-to-show-allocated-host-port-in-info-card/3390/3). Deleting this file will cause a rendering error on job card while job is waiting to be queued.