### PR TITLE
Update PBS to use run name

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -31,6 +31,7 @@ attributes:
         label: "Run Name"
         placeholder: "Enter your run name"
         pattern: '^[A-Za-z0-9_\- ]+$'
+        required: true
         help: |
             <a>Alphanumeric and "_" only</a>
 

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -11,7 +11,7 @@ script:
         - "-A kod_proteinfold"
         - "-l select=1:ncpus=2:mem=2gb"
         - "-l walltime=48:00:00"
-        - "-N kod_proteinfold"
+        - "-N <%= (run_name || 'kod_proteinfold').gsub(' ', '_') %>"
     email:
         - "<%= ENV['USER'] %>@ad.unsw.edu.au"
     email_on_terminated: "<%= email_on_terminated %>"


### PR DESCRIPTION
- Now submits pbs jobs with the jobname matching the kod run name
- Addresses https://github.com/unsw-edu-au/kod-proteinfold/issues/48
- Blocks submitting with a blank run name which would cause a bug