### PR TITLE
Bump nextflow version and other preparations for Proteinfold 2.0.0

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -9,7 +9,7 @@ batch_connect:
 script:
     native:
         - "-A kod_proteinfold"
-        - "-l select=1:ncpus=2:mem=2gb"
+        - "-l select=1:ncpus=2:mem=4gb"
         - "-l walltime=48:00:00"
         - "-N <%= (run_name || 'kod_proteinfold').gsub(' ', '_') %>"
     email:

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -74,7 +74,7 @@ function check_depend_version() {
 check_depend_version
 
 module purge
-module load java/21 nextflow/24
+module load java/21 nextflow/25
 
 # Check if the input is an amino acid sequence or a path
 user_input="<%= context.samplesheet %>"
@@ -142,7 +142,7 @@ fi
 
 [[ "<%= context.af_method %>" == "af2"  ]] && PROT_MODE="alphafold2" && ARGS="--alphafold2_db ${DB_PATH} --alphafold2_model_preset ${prot_mode} --full_dbs ${FULL_DB} --alphafold2_mode split_msa_prediction"
 [[ "<%= context.af_method %>" == "cf"   ]] && PROT_MODE="colabfold" && ARGS="--colabfold_db ${DB_PATH}"
-[[ "<%= context.af_method %>" == "esmf" ]] && PROT_MODE="esmfold" && ARGS="--esmfold_db ${DB_PATH}/esmfold_weights --esmfold_model_preset ${prot_mode}"
+[[ "<%= context.af_method %>" == "esmf" ]] && PROT_MODE="esmfold" && ARGS="--esmfold_db ${DB_PATH} --esmfold_model_preset ${prot_mode}"
 [[ "<%= context.af_method %>" == "rfaa" ]] && PROT_MODE="rosettafold_all_atom" && ARGS="--rosettafold_all_atom_db ${DB_PATH}"
 [[ "<%= context.af_method %>" == "hf3"  ]] && PROT_MODE="helixfold3" && ARGS="--helixfold3_db ${DB_PATH}"
 


### PR DESCRIPTION
- Updates Nextflow to 25 for compatibility with new schema
- ESMFold DB path changed to match latest version
- Submit memory increased to match `process_single` allowing the use of `executor = local` for low resource jobs. This cuts down on time spent waiting for the scheduler