### PR TITLE
Add more input options: single plaintext file and colon separated multimers

### DIFF
--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,5 +1,6 @@
 form:
     - samplesheet
+    - samplesheet_help
     - run_name
     - af_method
     - prot_mode
@@ -17,15 +18,14 @@ attributes:
         pattern: "*.csv^"
         placeholder: "path/to/file(s) or sequence 'NLYIQWLKDGGPSSGRPPPS'"
         required: true
+    samplesheet_help:
+        class: "d-none"
+        label: "Input Options"
         help: |
-            <b>Input options:</b>
-            <br>• <b>Directory:</b> <code>/srv/scratch/z3141592/my_experiment/</code>
+            • <b>Directory:</b> <code>/srv/scratch/z3141592/my_experiment/</code>
             <br>• <b>Single file:</b> <code>protein.fasta</code>, <code>protein.yaml</code>, or <code>samplesheet.csv</code>
             <br>• <b>Sequence:</b> <code>NLYIQWLKDGGPSSGRPPPS</code> or <code>NLYIQWLKDGGPSSGRPPPS:MKTVRQERLKSDHELFRTHT</code>
             <br>📖 <a href="https://unsw.sharepoint.com/sites/StructuralBiologyFacility-UserDocumentation/SitePages/ProteinFold-User-Guide.aspx?ga=1#preparing-your-inputs">User Guide</a> for advanced options.
-            <div style="padding: 0.375rem 0.75rem; background-color: #E2BEBE; border: 2px solid #761313; border-radius: var(--bs-border-radius); color: #761313; box-shadow: var(--bs-box-shadow-inset)">
-              <span><b>Warning!</b> Please ensure your input data (e.g., FASTA file or run name) does not contain sensitive data. Katana is <b>NOT</b> suitable for sensitive or highly sensitive data. You should use the UNSW Data Classification scheme to classify your data and learn about managing your research data by visiting the <a style="color: #5B5050" href="https://research.unsw.edu.au/research-data-management-hub">Research Data Management Hub.</a></span>
-            </div>
     run_name:
         widget: "text_field"
         label: "Run Name"

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -12,28 +12,17 @@ cluster: "katana"
 
 attributes:
     samplesheet:
-        widget: "text_field"
+        widget: "path_selector"
+        label: "Input"
         pattern: "*.csv^"
         placeholder: "path/to/file(s) or sequence 'NLYIQWLKDGGPSSGRPPPS'"
         required: true
         help: |
-            <h4>Acceptable inputs</h4>
-            <ul>
-                <li>
-                    <b>Option 1:</b> Directory containing <a href="https://en.wikipedia.org/wiki/FASTA_format">Fasta</a> file(s):
-                    <code>/srv/scratch/z3141592/my_experiment/</code>
-                </li>
-                <ul>
-                <li>
-                    NOTE: This will make predictions for every file in the directory.
-                </li>
-                </ul>
-                <li>
-                    <b>Option 2:</b> Directly paste an Amino acid sequence in to samplesheet box above:
-                    <code>NLYIQWLKDGGPSSGRPPPS</code>
-                </li>
- 
-            </ul>
+            <b>Input options:</b>
+            <br>• <b>Directory:</b> <code>/srv/scratch/z3141592/my_experiment/</code>
+            <br>• <b>Single file:</b> <code>protein.fasta</code>, <code>protein.yaml</code>, or <code>samplesheet.csv</code>
+            <br>• <b>Sequence:</b> <code>NLYIQWLKDGGPSSGRPPPS</code> or <code>NLYIQWLKDGGPSSGRPPPS:MKTVRQERLKSDHELFRTHT</code>
+            <br>📖 <a href="https://unsw.sharepoint.com/sites/StructuralBiologyFacility-UserDocumentation/SitePages/ProteinFold-User-Guide.aspx?ga=1#preparing-your-inputs">User Guide</a> for advanced options.
             <div style="padding: 0.375rem 0.75rem; background-color: #E2BEBE; border: 2px solid #761313; border-radius: var(--bs-border-radius); color: #761313; box-shadow: var(--bs-box-shadow-inset)">
               <span><b>Warning!</b> Please ensure your input data (e.g., FASTA file or run name) does not contain sensitive data. Katana is <b>NOT</b> suitable for sensitive or highly sensitive data. You should use the UNSW Data Classification scheme to classify your data and learn about managing your research data by visiting the <a style="color: #5B5050" href="https://research.unsw.edu.au/research-data-management-hub">Research Data Management Hub.</a></span>
             </div>

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -1,4 +1,5 @@
 form:
+    - data_warning
     - samplesheet
     - samplesheet_help
     - run_name
@@ -12,6 +13,12 @@ form:
 cluster: "katana"
 
 attributes:
+    data_warning:
+        class: "d-none"
+        help: |
+            <div style="padding: 0.375rem 0.75rem; background-color: #E2BEBE; border: 2px solid #761313; border-radius: 0.25rem; color: #761313;">
+              <span><b>Warning!</b> Please ensure your input data (e.g., FASTA file or run name) does not contain sensitive data. Katana is <b>NOT</b> suitable for sensitive or highly sensitive data. You should use the UNSW Data Classification scheme to classify your data and learn about managing your research data by visiting the <a style="color: #5B5050" href="https://research.unsw.edu.au/research-data-management-hub">Research Data Management Hub.</a></span>
+            </div>
     samplesheet:
         widget: "path_selector"
         label: "Input"

--- a/manifest.yml
+++ b/manifest.yml
@@ -3,9 +3,6 @@ name: Proteinfold
 category: Interactive Apps
 subcategory: Biology
 role: batch_connect
-description: "<img src=\"https://www.analytical.unsw.edu.au/sites/default/files/styles/feature_wide/public/facility_image/SBF_0.jpg\"
-  style=\"max-width: 200px\"/><br>
-Web interface to run <a href=\"https://nf-co.re/proteinfold/dev\">nf-core/proteinfold</a> for computational structure prediction.
-<div style=\"padding: 0.375rem 0.75rem; background-color: #E2BEBE; border: 2px solid #761313; border-radius: 0.25rem; color: #761313;\">
-  <span><b>Warning!</b> Please ensure your input data (e.g., FASTA file or run name) does not contain sensitive data. Katana is <b>NOT</b> suitable for sensitive or highly sensitive data. You should use the UNSW Data Classification scheme to classify your data and learn about managing your research data by visiting the <a style=\"color: #5B5050\" href=\"https://research.unsw.edu.au/research-data-management-hub\">Research Data Management Hub.</a></span>
-</div>"
+description: |
+  <img src="https://www.analytical.unsw.edu.au/sites/default/files/styles/feature_wide/public/facility_image/SBF_0.jpg" style="max-width: 200px"/><br>
+  Web interface to run <a href="https://nf-co.re/proteinfold/dev">nf-core/proteinfold</a> for computational structure prediction.

--- a/manifest.yml
+++ b/manifest.yml
@@ -6,4 +6,6 @@ role: batch_connect
 description: "<img src=\"https://www.analytical.unsw.edu.au/sites/default/files/styles/feature_wide/public/facility_image/SBF_0.jpg\"
   style=\"max-width: 200px\"/><br>
 Web interface to run <a href=\"https://nf-co.re/proteinfold/dev\">nf-core/proteinfold</a> for computational structure prediction.
-Please refer to the <a href=\"https://unsw.sharepoint.com/:u:/s/StructuralBiologyFacility-UserDocumentation/EYBQBPXcXNhLhAgLvdQOvo4Bw9-nq_IoXTcPOYbP7s2woA?e=TJQP8ohttps://nf-co.re/proteinfold/dev\">User Guide</a>"
+<div style=\"padding: 0.375rem 0.75rem; background-color: #E2BEBE; border: 2px solid #761313; border-radius: 0.25rem; color: #761313;\">
+  <span><b>Warning!</b> Please ensure your input data (e.g., FASTA file or run name) does not contain sensitive data. Katana is <b>NOT</b> suitable for sensitive or highly sensitive data. You should use the UNSW Data Classification scheme to classify your data and learn about managing your research data by visiting the <a style=\"color: #5B5050\" href=\"https://research.unsw.edu.au/research-data-management-hub\">Research Data Management Hub.</a></span>
+</div>"

--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -10,7 +10,7 @@ script:
     native:
     # ColabFold local DBs are only available locally on certain nodes. This is an example method for catching local ColabFold runs
      <% if (af_method == "colabfold" || af_method == "boltz") && msa_server == "local" %>
-         - "-l select=1:mwacgpu200=gpu-mwac:ncpus=8:ngpus=1:mem=125gb"
+         - "-l select=1:mwacgpu200=gpu-mwac:ncpus=8:ngpus=1:mem=124gb"
          - "-l walltime=12:00:00"
          - "-N <%= (run_name || 'kod_proteinfold').gsub(' ', '_') %>"
      <% else %>

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -105,7 +105,7 @@ function convert_colon_delimited_to_fasta() {
 MODE=""
 [[ "${user_input}" =~ ^[\ A-Z:\*\-]*$ ]] && MODE="MANUAL_INPUT"
 [[ "${user_input}" =~ ^.*\.csv$ ]] && MODE="SAMPLESHEET_INPUT"
-[[ "${user_input}" =~ ^\S+\.(fa(sta)?|y(a)?ml|json)$ ]] && MODE="FASTA_INPUT"
+[[ "${user_input}" =~ \.(fa(sta)?|y(a)?ml)$ ]] && MODE="FASTA_INPUT"
 [[ "${MODE}" == "" ]] && MODE="DIRECTORY"
 
 echo "${MODE}"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -81,10 +81,31 @@ module load java/21 nextflow/25
 user_input="<%= context.samplesheet %>"
 echo "${user_input}" >> $HOME/debug.txt
 
+# Function to convert colon-delimited sequences to multi-FASTA format
+function convert_colon_delimited_to_fasta() {
+    local sequence="$1"
+    local output_file="$2"
+    if [[ "${sequence}" == *":"* ]]; then
+        echo "Conversion started..."
+        IFS=':' read -ra chains <<< "${sequence}"
+        > "${output_file}"
+        chain_labels="ABCDEFGHIJKLMNOPQRSTUVWXYZ"
+        for i in "${!chains[@]}"; do
+            chain_label=${chain_labels:$i:1}
+            echo ">${chain_label}" >> "${output_file}"
+            echo "${chains[$i]}" >> "${output_file}"
+        done
+        echo "Converted ${#chains[@]} chains to ${output_file}"
+        return 0
+    else
+        return 1
+    fi
+}
+
 MODE=""
 [[ "${user_input}" =~ ^[\ A-Z:\*\-]*$ ]] && MODE="MANUAL_INPUT"
 [[ "${user_input}" =~ ^.*\.csv$ ]] && MODE="SAMPLESHEET_INPUT"
-[[ "${user_input}" =~ ^.*\.(fasta|fa|fas|faa|ffn|fna|frn|yaml|yml|json|txt|seq|aa|pep|protein)$ ]] && MODE="FASTA_INPUT"
+[[ "${user_input}" =~ ^\S+\.(fa(sta)?|y(a)?ml|json)$ ]] && MODE="FASTA_INPUT"
 [[ "${MODE}" == "" ]] && MODE="DIRECTORY"
 
 echo "${MODE}"
@@ -167,8 +188,19 @@ esac
 
 if [ "${MODE}" == "MANUAL_INPUT" ];
 then
-    create-samplesheet --aa-string "${user_input}" --suffix "${prot_mode}" ${OUTPUT_FORMAT}
-    SAMPLESHEET="$(pwd)/samplesheet.csv"
+    # Check if input contains colon-delimited sequences
+    if [[ "${user_input}" == *":"* ]]; then
+        echo "Detected colon-delimited sequence input, converting to multi-FASTA format..."
+        mkdir -p fasta
+        temp_fasta_file="./fasta/converted_multimer.fasta"
+        convert_colon_delimited_to_fasta "${user_input}" "${temp_fasta_file}"
+        create-samplesheet --directory "./fasta" --suffix "${prot_mode}" ${OUTPUT_FORMAT}
+        SAMPLESHEET="$(pwd)/samplesheet.csv"
+        echo "Successfully converted colon-delimited input to multi-FASTA and created samplesheet"
+    else
+        create-samplesheet --aa-string "${user_input}" --suffix "${prot_mode}" ${OUTPUT_FORMAT}
+        SAMPLESHEET="$(pwd)/samplesheet.csv"
+    fi
 fi
 
 if [ "${MODE}" == "SAMPLESHEET_INPUT" ];

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -73,6 +73,7 @@ function check_depend_version() {
 
 check_depend_version
 
+# TODO: This can be handled by instituional nextflow .config allowing for better portability
 module purge
 module load java/21 nextflow/25
 
@@ -84,6 +85,7 @@ echo "${user_input}" >> $HOME/debug.txt
 MODE=""
 [[ "${user_input}" =~ ^[\ A-Z\*\-]*$ ]] && MODE="MANUAL_INPUT"
 [[ "${user_input}" =~ ^.*\.csv$ ]] && MODE="SAMPLESHEET_INPUT"
+[[ "${user_input}" =~ ^.*\.(fasta|fa|txt)$ ]] && MODE="FASTA_INPUT"
 [[ "${MODE}" == "" ]] && MODE="DIRECTORY"
 
 echo "${MODE}"
@@ -93,6 +95,7 @@ SAMPLESHEET=""
 
 af_method="<%= context.af_method %>"
 prot_mode="<%= context.prot_mode %>"
+
 # Remap prot_mode if af_method is esmfold and prot_mode is monomer_ptm
 if [ "${af_method}" == "esmfold" ] && [ "${prot_mode}" == "monomer_ptm" ]; then
     prot_mode="monomer"
@@ -124,6 +127,14 @@ fi
 if [ "${MODE}" == "SAMPLESHEET_INPUT" ];
 then
     SAMPLESHEET="${user_input}"
+fi
+
+if [ "${MODE}" == "FASTA_INPUT" ];
+then
+    mkdir fasta
+    cp "${user_input}" ./fasta/
+    create-samplesheet --directory "./fasta" --suffix "${prot_mode}" ${OUTPUT_FORMAT}
+    SAMPLESHEET="$(pwd)/samplesheet.csv"
 fi
 
 if [ "${MODE}" == "DIRECTORY" ];

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -164,6 +164,12 @@ SAMPLESHEET=""
 af_method="<%= context.af_method %>"
 prot_mode="<%= context.prot_mode %>"
 
+# Auto-set multimer mode for colon-delimited sequences
+if [[ "${user_input}" == *":"* ]]; then
+    echo "Colon-delimited sequence detected, automatically setting mode to multimer"
+    prot_mode="multimer"
+fi
+
 # Remap prot_mode if af_method is esmfold and prot_mode is monomer_ptm
 if [ "${af_method}" == "esmfold" ] && [ "${prot_mode}" == "monomer_ptm" ]; then
     prot_mode="monomer"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -81,11 +81,10 @@ module load java/21 nextflow/25
 user_input="<%= context.samplesheet %>"
 echo "${user_input}" >> $HOME/debug.txt
 
-
 MODE=""
 [[ "${user_input}" =~ ^[\ A-Z:\*\-]*$ ]] && MODE="MANUAL_INPUT"
 [[ "${user_input}" =~ ^.*\.csv$ ]] && MODE="SAMPLESHEET_INPUT"
-[[ "${user_input}" =~ ^.*\.(fasta|fa|txt)$ ]] && MODE="FASTA_INPUT"
+[[ "${user_input}" =~ ^.*\.(fasta|fa|fas|faa|ffn|fna|frn|yaml|yml|json|txt|seq|aa|pep|protein)$ ]] && MODE="FASTA_INPUT"
 [[ "${MODE}" == "" ]] && MODE="DIRECTORY"
 
 echo "${MODE}"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -73,7 +73,7 @@ function check_depend_version() {
 
 check_depend_version
 
-# TODO: This can be handled by instituional nextflow .config allowing for better portability
+# TODO: This can be handled by institutional nextflow .config allowing for better portability
 module purge
 module load java/21 nextflow/25
 
@@ -83,7 +83,7 @@ echo "${user_input}" >> $HOME/debug.txt
 
 
 MODE=""
-[[ "${user_input}" =~ ^[\ A-Z\*\-]*$ ]] && MODE="MANUAL_INPUT"
+[[ "${user_input}" =~ ^[\ A-Z:\*\-]*$ ]] && MODE="MANUAL_INPUT"
 [[ "${user_input}" =~ ^.*\.csv$ ]] && MODE="SAMPLESHEET_INPUT"
 [[ "${user_input}" =~ ^.*\.(fasta|fa|txt)$ ]] && MODE="FASTA_INPUT"
 [[ "${MODE}" == "" ]] && MODE="DIRECTORY"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -89,6 +89,54 @@ MODE=""
 
 echo "${MODE}"
 
+# Validate input file format compatibility with selected method
+af_method="<%= context.af_method %>"
+
+# Check YAML/YML compatibility - only supported by Boltz and RoseTTAFold-All-Atom
+if [ "${MODE}" == "FASTA_INPUT" ] && [[ "${user_input}" =~ \.(yaml|yml)$ ]]; then
+    if [ "${af_method}" != "boltz" ] && [ "${af_method}" != "rosettafold_all_atom" ]; then
+        echo "ERROR: YAML/YML input files are only supported by Boltz and RoseTTAFold-All-Atom methods."
+        echo "Current method: ${af_method}"
+        exit 1
+    fi
+fi
+
+# Check JSON compatibility - only supported by HelixFold3
+if [ "${MODE}" == "FASTA_INPUT" ] && [[ "${user_input}" =~ \.json$ ]]; then
+    if [ "${af_method}" != "helixfold3" ]; then
+        echo "ERROR: JSON input files are only supported by the HelixFold3 method."
+        echo "Current method: ${af_method}"
+        exit 1
+    fi
+fi
+
+# Check directory contents for incompatible file types
+if [ "${MODE}" == "DIRECTORY" ] && [ -d "${user_input}" ]; then
+    # Check for YAML/YML files in directory
+    if [ "${af_method}" != "boltz" ] && [ "${af_method}" != "rosettafold_all_atom" ]; then
+        yaml_files=$(find "${user_input}" -type f \( -name "*.yaml" -o -name "*.yml" \) 2>/dev/null || true)
+        if [ ! -z "${yaml_files}" ]; then
+            echo "ERROR: Directory contains YAML/YML files, which are only supported by Boltz and RoseTTAFold-All-Atom methods."
+            echo "Current method: ${af_method}"
+            echo "Found YAML/YML files:"
+            echo "${yaml_files}"
+            exit 1
+        fi
+    fi
+
+    # Check for JSON files in directory
+    if [ "${af_method}" != "helixfold3" ]; then
+        json_files=$(find "${user_input}" -type f -name "*.json" 2>/dev/null || true)
+        if [ ! -z "${json_files}" ]; then
+            echo "ERROR: Directory contains JSON files, which are only supported by the HelixFold3 method."
+            echo "Current method: ${af_method}"
+            echo "Found JSON files:"
+            echo "${json_files}"
+            exit 1
+        fi
+    fi
+fi
+
 create-samplesheet --version
 SAMPLESHEET=""
 


### PR DESCRIPTION
- Now correctly handles single plaintext file inputs
- Will accept manual input with a ":" separating fasta strings

## TODO
- [x] Check input filetype and crash gracefully if unsupported by the selected mode
- [x] Convert ":" delimited inputs into multi-fasta files