### PR TITLE
Use output.log for completed card and added sanitisation filter

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ood-proteinfold (OnDemand App)
 
-`ood-proteinfold` is an [Open OnDemand](https://openondemand.org/) interactive app for computational protein structure prediction using [Proteinfold](https://nf-co.re/proteinfold/) ([AlphaFold2](https://github.com/google-deepmind/alphafold/), [Boltz](https://github.com/jwohlwend/boltz/), [ColabFold](https://github.com/sokrypton/ColabFold), [ESMFold](https://github.com/facebookresearch/esm), and [RoseTTAFold-All-Atom](https://github.com/baker-laboratory/RoseTTAFold-All-Atom/)) originally built for [UNSW's Katana HPC](https://www.unsw.edu.au/research/facilities-and-infrastructure/find-an-instrument/restech-instruments/katana).
+`ood-proteinfold` is an [Open OnDemand](https://openondemand.org/) interactive app for computational protein structure prediction using [Proteinfold](https://nf-co.re/proteinfold/) ([AlphaFold2](https://github.com/google-deepmind/alphafold/), [Boltz](https://github.com/jwohlwend/boltz/), [ColabFold](https://github.com/sokrypton/ColabFold) and [ESMFold](https://github.com/facebookresearch/esm) originally built for [UNSW's Katana HPC](https://www.unsw.edu.au/research/facilities-and-infrastructure/find-an-instrument/restech-instruments/katana).
 
 ## Features
 

--- a/completed.html.erb
+++ b/completed.html.erb
@@ -69,8 +69,44 @@ def sanitize_live_log(text)
   compact.join("\n").strip
 end
 
-base_out_dir = (connect.respond_to?(:base_out_dir) && !connect.base_out_dir.blank?) ? connect.base_out_dir : "/srv/scratch/#{connect.user}/proteinfold_output"
-results_url_base = (connect.respond_to?(:results_url_base) && !connect.results_url_base.blank?) ? connect.results_url_base : "/pun/sys/dashboard/files/fs"
+def sanitize_output_log(text)
+  return nil if text.nil?
+
+  lines = text.split("\n")
+  cleaned = []
+  index = 0
+
+  while index < lines.length
+    line = lines[index]
+
+    if line.start_with?("WARN: [PBSPRO] queue status cannot be fetched")
+      index += 1
+      index += 1 while index < lines.length && !lines[index].strip.empty?
+      index += 1 if index < lines.length && lines[index].strip.empty?
+      next
+    end
+
+    if line.strip == "Cleaning up..."
+      break
+    end
+
+    if line.match?(/^=+$/) && index + 1 < lines.length && lines[index + 1].include?("Resource Usage on ")
+      break
+    end
+
+    cleaned << line
+    index += 1
+  end
+
+  while cleaned.any? && cleaned.last.strip.empty?
+    cleaned.pop
+  end
+
+  cleaned.join("\n").strip
+end
+
+base_out_dir = (connect.respond_to?(:base_out_dir) && !connect.base_out_dir.blank?) ? connect.base_out_dir : portal_default_base_out_dir
+results_url_base = (connect.respond_to?(:results_url_base) && !connect.results_url_base.blank?) ? connect.results_url_base : portal_default_results_url_base
 session_output_dir = (connect.respond_to?(:session_output_dir) && !connect.session_output_dir.blank?) ? connect.session_output_dir : nil
 log_dir = session_output_dir || File.join(base_out_dir, connect.run_dir)
 live_log_path = File.join(log_dir, "live_log.log")
@@ -79,7 +115,11 @@ output_log_path = File.join(log_dir, "output.log")
 output_log_url = file_url(results_url_base, output_log_path)
 summary_log_url = File.file?(output_log_path) ? output_log_url : live_log_url
 summary_log_label = File.file?(output_log_path) ? "output.log" : "live_log.log"
-log_text = sanitize_live_log(tail_text(live_log_path))
+log_text = if File.file?(output_log_path)
+  sanitize_output_log(tail_text(output_log_path, 16384, 40))
+else
+  sanitize_live_log(tail_text(live_log_path))
+end
 %>
 <div class="ood-completed-log-card">
 <div><b>Log</b>: <a target="_blank" rel="noopener" href="https://kod.restech.unsw.edu.au<%= summary_log_url %>"><%= summary_log_label %></a></div>

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -54,14 +54,12 @@ attributes:
                 <li><b>AlphaFold2.3</b> High accuracy, Slower - <a href="https://doi.org/10.1038/s41586-021-03819-2">Paper</a></li>
                 <li><b>ColabFold</b> High accuracy - <a href="https://doi.org/10.1038/s41592-022-01488-1">Paper</a></li>
                 <li><b>ESMFold</b> Medium/Low accuracy, Fastest; No evolutionary sequence calculations - <a href="https://doi.org/10.1126/science.ade2574">Paper</a></li>
-                <li><b>RoseTTAFold-All-Atom</b> Medium accuracy, Slower; Supports all atom modelling - <a href="https://doi.org/10.1126/science.adl2528">Paper</a></li>
             </ul>
         options:
             - ["Boltz", "boltz", data-hide-prot_mode: true, data-hide-full_dbs: true, data-hide-colabfold_num_recycles: true, data-hide-esmfold_num_recycles: true]
             - ["AlphaFold2", "alphafold2", data-hide-colabfold_num_recycles: true, data-hide-esmfold_num_recycles: true, data-hide-boltz_use_potentials: true]
             - ["ColabFold", "colabfold", data-hide-full_dbs: true, data-hide-esmfold_num_recycles: true, data-hide-boltz_use_potentials: true]
             - ["ESMFold", "esmfold", data-hide-full_dbs: true, data-hide-colabfold_num_recycles: true, data-hide-boltz_use_potentials: true]
-            - ["RoseTTAFold-All-Atom", "rosettafold_all_atom", data-hide-prot_mode: true, data-hide-full_dbs: true, data-hide-colabfold_num_recycles: true, data-hide-esmfold_num_recycles: true, data-hide-boltz_use_potentials: true]
         display: true
 
     prot_mode:

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -112,10 +112,10 @@ echo "${MODE}"
 # Validate input file format compatibility with selected method
 af_method="<%= context.af_method %>"
 
-# Check YAML/YML compatibility - only supported by Boltz and RoseTTAFold-All-Atom
+# Check YAML/YML compatibility - only supported by Boltz
 if [ "${MODE}" == "FASTA_INPUT" ] && [[ "${user_input}" =~ \.(yaml|yml)$ ]]; then
-    if [ "${af_method}" != "boltz" ] && [ "${af_method}" != "rosettafold_all_atom" ]; then
-        echo "ERROR: YAML/YML input files are only supported by Boltz and RoseTTAFold-All-Atom methods."
+    if [ "${af_method}" != "boltz" ]; then
+        echo "ERROR: YAML/YML input files are only supported by Boltz."
         echo "Current method: ${af_method}"
         exit 1
     fi
@@ -133,10 +133,10 @@ fi
 # Check directory contents for incompatible file types
 if [ "${MODE}" == "DIRECTORY" ] && [ -d "${user_input}" ]; then
     # Check for YAML/YML files in directory
-    if [ "${af_method}" != "boltz" ] && [ "${af_method}" != "rosettafold_all_atom" ]; then
+    if [ "${af_method}" != "boltz" ]; then
         yaml_files=$(find "${user_input}" -type f \( -name "*.yaml" -o -name "*.yml" \) 2>/dev/null || true)
         if [ ! -z "${yaml_files}" ]; then
-            echo "ERROR: Directory contains YAML/YML files, which are only supported by Boltz and RoseTTAFold-All-Atom methods."
+            echo "ERROR: Directory contains YAML/YML files, which are only supported by Boltz."
             echo "Current method: ${af_method}"
             echo "Found YAML/YML files:"
             echo "${yaml_files}"
@@ -285,9 +285,6 @@ if [ "<%= context.af_method %>" == "esmfold" ]; then
         ARGS="${ARGS} --esmfold_num_recycles ${ESMFOLD_RECYCLES}"
     fi
 fi
-
-[[ "<%= context.af_method %>" == "rosettafold_all_atom" ]] && PROT_MODE="rosettafold_all_atom" && ARGS="${ARGS} --rosettafold_all_atom_db ${DB_PATH}"
-[[ "<%= context.af_method %>" == "helixfold3"  ]] && PROT_MODE="helixfold3" && ARGS="${ARGS} --helixfold3_db ${DB_PATH}"
 
 nextflow -c "${PROJECT_ROOT}/kod_proteinfold-${RUN_ENVIRONMENT}.config" run ${REPOSITORY} -r ${BRANCH} -latest \
     --input "${SAMPLESHEET}" \


### PR DESCRIPTION
Closes https://github.com/Australian-Structural-Biology-Computing/ood-proteinfold/issues/55

Use `output.log` for the completed log preview instead of `live_log.log`. This exposes termination messages such as PBS walltime kill.

Sanitiser script trims noisy queue-status output, cleanup text, and the trailing resource-usage report.

Preceded by PR https://github.com/Australian-Structural-Biology-Computing/ood-proteinfold/pull/84