### PR TITLE
Removes deprecated RFAA mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ood-proteinfold (OnDemand App)
 
-`ood-proteinfold` is an [Open OnDemand](https://openondemand.org/) interactive app for computational protein structure prediction using [Proteinfold](https://nf-co.re/proteinfold/) ([AlphaFold2](https://github.com/google-deepmind/alphafold/), [Boltz](https://github.com/jwohlwend/boltz/), [ColabFold](https://github.com/sokrypton/ColabFold), [ESMFold](https://github.com/facebookresearch/esm), and [RoseTTAFold-All-Atom](https://github.com/baker-laboratory/RoseTTAFold-All-Atom/)) originally built for [UNSW's Katana HPC](https://www.unsw.edu.au/research/facilities-and-infrastructure/find-an-instrument/restech-instruments/katana).
+`ood-proteinfold` is an [Open OnDemand](https://openondemand.org/) interactive app for computational protein structure prediction using [Proteinfold](https://nf-co.re/proteinfold/) ([AlphaFold2](https://github.com/google-deepmind/alphafold/), [Boltz](https://github.com/jwohlwend/boltz/), [ColabFold](https://github.com/sokrypton/ColabFold) and [ESMFold](https://github.com/facebookresearch/esm) originally built for [UNSW's Katana HPC](https://www.unsw.edu.au/research/facilities-and-infrastructure/find-an-instrument/restech-instruments/katana).
 
 ## Features
 

--- a/form.yml.erb
+++ b/form.yml.erb
@@ -54,14 +54,12 @@ attributes:
                 <li><b>AlphaFold2.3</b> High accuracy, Slower - <a href="https://doi.org/10.1038/s41586-021-03819-2">Paper</a></li>
                 <li><b>ColabFold</b> High accuracy - <a href="https://doi.org/10.1038/s41592-022-01488-1">Paper</a></li>
                 <li><b>ESMFold</b> Medium/Low accuracy, Fastest; No evolutionary sequence calculations - <a href="https://doi.org/10.1126/science.ade2574">Paper</a></li>
-                <li><b>RoseTTAFold-All-Atom</b> Medium accuracy, Slower; Supports all atom modelling - <a href="https://doi.org/10.1126/science.adl2528">Paper</a></li>
             </ul>
         options:
             - ["Boltz", "boltz", data-hide-prot_mode: true, data-hide-full_dbs: true, data-hide-colabfold_num_recycles: true, data-hide-esmfold_num_recycles: true]
             - ["AlphaFold2", "alphafold2", data-hide-colabfold_num_recycles: true, data-hide-esmfold_num_recycles: true, data-hide-boltz_use_potentials: true]
             - ["ColabFold", "colabfold", data-hide-full_dbs: true, data-hide-esmfold_num_recycles: true, data-hide-boltz_use_potentials: true]
             - ["ESMFold", "esmfold", data-hide-full_dbs: true, data-hide-colabfold_num_recycles: true, data-hide-boltz_use_potentials: true]
-            - ["RoseTTAFold-All-Atom", "rosettafold_all_atom", data-hide-prot_mode: true, data-hide-full_dbs: true, data-hide-colabfold_num_recycles: true, data-hide-esmfold_num_recycles: true, data-hide-boltz_use_potentials: true]
         display: true
 
     prot_mode:

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -112,10 +112,10 @@ echo "${MODE}"
 # Validate input file format compatibility with selected method
 af_method="<%= context.af_method %>"
 
-# Check YAML/YML compatibility - only supported by Boltz and RoseTTAFold-All-Atom
+# Check YAML/YML compatibility - only supported by Boltz
 if [ "${MODE}" == "FASTA_INPUT" ] && [[ "${user_input}" =~ \.(yaml|yml)$ ]]; then
-    if [ "${af_method}" != "boltz" ] && [ "${af_method}" != "rosettafold_all_atom" ]; then
-        echo "ERROR: YAML/YML input files are only supported by Boltz and RoseTTAFold-All-Atom methods."
+    if [ "${af_method}" != "boltz" ]; then
+        echo "ERROR: YAML/YML input files are only supported by Boltz."
         echo "Current method: ${af_method}"
         exit 1
     fi
@@ -133,10 +133,10 @@ fi
 # Check directory contents for incompatible file types
 if [ "${MODE}" == "DIRECTORY" ] && [ -d "${user_input}" ]; then
     # Check for YAML/YML files in directory
-    if [ "${af_method}" != "boltz" ] && [ "${af_method}" != "rosettafold_all_atom" ]; then
+    if [ "${af_method}" != "boltz" ]; then
         yaml_files=$(find "${user_input}" -type f \( -name "*.yaml" -o -name "*.yml" \) 2>/dev/null || true)
         if [ ! -z "${yaml_files}" ]; then
-            echo "ERROR: Directory contains YAML/YML files, which are only supported by Boltz and RoseTTAFold-All-Atom methods."
+            echo "ERROR: Directory contains YAML/YML files, which are only supported by Boltz."
             echo "Current method: ${af_method}"
             echo "Found YAML/YML files:"
             echo "${yaml_files}"
@@ -285,9 +285,6 @@ if [ "<%= context.af_method %>" == "esmfold" ]; then
         ARGS="${ARGS} --esmfold_num_recycles ${ESMFOLD_RECYCLES}"
     fi
 fi
-
-[[ "<%= context.af_method %>" == "rosettafold_all_atom" ]] && PROT_MODE="rosettafold_all_atom" && ARGS="${ARGS} --rosettafold_all_atom_db ${DB_PATH}"
-[[ "<%= context.af_method %>" == "helixfold3"  ]] && PROT_MODE="helixfold3" && ARGS="${ARGS} --helixfold3_db ${DB_PATH}"
 
 nextflow -c "${PROJECT_ROOT}/kod_proteinfold-${RUN_ENVIRONMENT}.config" run ${REPOSITORY} -r ${BRANCH} -latest \
     --input "${SAMPLESHEET}" \


### PR DESCRIPTION
Closes https://github.com/Australian-Structural-Biology-Computing/ood-proteinfold/issues/81

There are few if any situations when RoseTTAFold-All-Atom would be preferable to another mode (e.g. Boltz). Removes it as an option in the form to simplify user experience.