### PR TITLE
Fix input preprocessing and update submission options

### DIFF
--- a/submit.yml.erb
+++ b/submit.yml.erb
@@ -13,9 +13,10 @@ script:
     native:
     # ColabFold local DBs are only available locally on certain nodes. This is an example method for catching local ColabFold runs
      <% if (af_method == "colabfold" || af_method == "boltz") && msa_server == "local" %>
-         - "-l select=1:mwacgpu200=gpu-mwac:ncpus=8:ngpus=1:mem=124gb"
-         - "-l walltime=12:00:00"
+         - "-l select=1:mwacgpu12=gpu-mwac:ncpus=8:ngpus=1:mem=124gb"
+         - "-l walltime=48:00:00"
          - "-N <%= (run_name || 'kod_proteinfold').gsub(' ', '_') %>"
+         - "-A kod_proteinfold"
      <% else %>
         - "-A kod_proteinfold"
         - "-l select=1:ncpus=2:mem=4gb"

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -222,6 +222,7 @@ if [ "${MODE}" == "FASTA_INPUT" ];
 then
     mkdir -p fasta
     cp "${user_input}" ./fasta/
+    dos2unix ./fasta/*
     create-samplesheet --directory "./fasta" --suffix "${prot_mode}" ${OUTPUT_FORMAT}
     SAMPLESHEET="$(pwd)/samplesheet.csv"
 fi
@@ -234,10 +235,11 @@ then
     for filename in *
     do
         echo "${filename}"
-        ln -s "$(pwd)/${filename}" "$working_dir/fasta/$(echo ${filename} | sed --expression='s/\s/\-/g')"
+        cp "$(pwd)/${filename}" "$working_dir/fasta/$(echo ${filename} | sed --expression='s/\s/\-/g')"
     done
 
     cd ${working_dir}
+    dos2unix ./fasta/*
     create-samplesheet --directory "./fasta" --suffix "${prot_mode}" ${OUTPUT_FORMAT}
     SAMPLESHEET="$(pwd)/samplesheet.csv"
 fi


### PR DESCRIPTION
This pull request updates the job submission and sample preparation scripts to improve compatibility and reliability.

* Increased walltime from 12 to 48 hours to ensure jobs are directed to SBF nodes.
* Added the project flag to the job submission arguments.
* Added `dos2unix` conversion for all files in the `fasta` directory to ensure correct Unix line endings.
* Replaced symbolic linking (`ln -s`) with direct copying (`cp`) of input files to the working `fasta` directory to avoid downstream processing altering the originals.