### PR TITLE
Fix default repo and branch to stable release

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,10 @@ PROJECT_ROOT=/srv/scratch/sbf-pipelines/proteinfold
 DB_PATH=/srv/scratch/sbf-pipelines/proteinfold/dbs
 
 # Git branch to use for proteinfold
-BRANCH=master
+BRANCH=v2.0.0
 
 # Repository path for using alternative versions of proteinfold
-REPOSITORY=Australian-Structural-Biology-Computing/proteinfold
+REPOSITORY=nf-core/proteinfold
 
 # Debug group for permissions on debug files
 DEBUGGROUP=sbf-pipelines

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -10,8 +10,8 @@ fi
 RUN_ENVIRONMENT=${RUN_ENVIRONMENT:-prod}
 PROJECT_ROOT=${PROJECT_ROOT:-/srv/scratch/sbf-pipelines/proteinfold}
 DB_PATH=${DB_PATH:-/srv/scratch/sbf-pipelines/proteinfold/dbs}
-BRANCH=${BRANCH:-master}
-REPOSITORY=${REPOSITORY:-Australian-Structural-Biology-Computing/proteinfold}
+BRANCH=${BRANCH:-v2.0.0}
+REPOSITORY=${REPOSITORY:-nf-core/proteinfold}
 DEBUGGROUP=${DEBUGGROUP:-sbf}
 
 set -xo pipefail


### PR DESCRIPTION
Minor fix to move away from defaulting to ASBC fork's master branch and instead use nf-core's latest stable release.