### PR TITLE
Log run metadata to a shared directory

### DIFF
--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -13,6 +13,8 @@ DB_PATH=${DB_PATH:-/srv/scratch/sbf-pipelines/proteinfold/dbs}
 BRANCH=${BRANCH:-2.0.0}
 REPOSITORY=${REPOSITORY:-nf-core/proteinfold}
 DEBUGGROUP=${DEBUGGROUP:-sbf}
+METRICS_DIRECTORY=${METRICS_DIRECTORY:-/srv/scratch/sbf-pipelines/metrics}
+ENABLE_METRICS=${ENABLE_METRICS:-true}
 
 PROTEINFOLD_VERSION_SELECTION="<%= context.proteinfold_version %>"
 case "${PROTEINFOLD_VERSION_SELECTION}" in
@@ -373,6 +375,29 @@ fi
 
 if [ "${SAVE_INTERMEDIATES}" == "true" ]; then
     ARGS="${ARGS} --save_intermediates true"
+fi
+
+if [[ "${ENABLE_METRICS}" == "true" ]]; then
+  # Write metrics before starting the run Create yyyy/mm directory to avoid large file count in one directory and to make collecting metrics by month easier.
+  METRICS_LOG_PATH="${METRICS_DIRECTORY}/$(date +%Y/%m)"
+  mkdir -p "${METRICS_LOG_PATH}"
+
+  # Write json file containing job metrics.
+  NF_CONFIG="${NEXTFLOW_CONFIG_ARGS[@]}"
+  jq -n \
+    --arg date "$(date +%Y-%m-%dT%H:%M:%SZ%z)" \
+    --arg user "$(whoami)" \
+    --arg node "$(hostname)" \
+    --arg pbs_jobid "${PBS_JOBID}" \
+    --arg mode "${PROT_MODE}" \
+    --arg repository "${REPOSITORY}" \
+    --arg branch "${BRANCH}" \
+    --arg input "${SAMPLESHEET}" \
+    --arg outdir "${OUT_DIR}" \
+    --arg nf_config "${NF_CONFIG}" \
+    --arg args "${ARGS}" \
+    '{date: $date, user: $user, node: $node, pbs_jobid: $pbs_jobid, mode: $mode, repository: $repository, branch: $branch, input: $input, outdir: $outdir, nf_config: $nf_config, args: $args}' > "${METRICS_LOG_PATH}/$(date +%Y-%m-%dT%H:%M:%SZ%z)-$(whoami)-${PBS_JOBID%.*}.json"
+ 
 fi
 
 nextflow "${NEXTFLOW_CONFIG_ARGS[@]}" run ${REPOSITORY} -r ${BRANCH} -latest \

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -397,7 +397,7 @@ if [[ "${ENABLE_METRICS}" == "true" ]]; then
     --arg nf_config "${NF_CONFIG}" \
     --arg args "${ARGS}" \
     '{date: $date, user: $user, node: $node, pbs_jobid: $pbs_jobid, mode: $mode, repository: $repository, branch: $branch, input: $input, outdir: $outdir, nf_config: $nf_config, args: $args}' > "${METRICS_LOG_PATH}/$(date +%Y-%m-%dT%H:%M:%SZ%z)-$(whoami)-${PBS_JOBID%.*}.json"
- 
+
 fi
 
 nextflow "${NEXTFLOW_CONFIG_ARGS[@]}" run ${REPOSITORY} -r ${BRANCH} -latest \

--- a/template/script.sh.erb
+++ b/template/script.sh.erb
@@ -380,23 +380,24 @@ fi
 if [[ "${ENABLE_METRICS}" == "true" ]]; then
   # Write metrics before starting the run Create yyyy/mm directory to avoid large file count in one directory and to make collecting metrics by month easier.
   METRICS_LOG_PATH="${METRICS_DIRECTORY}/$(date +%Y/%m)"
-  mkdir -p "${METRICS_LOG_PATH}"
 
   # Write json file containing job metrics.
   NF_CONFIG="${NEXTFLOW_CONFIG_ARGS[@]}"
-  jq -n \
-    --arg date "$(date +%Y-%m-%dT%H:%M:%SZ%z)" \
-    --arg user "$(whoami)" \
-    --arg node "$(hostname)" \
-    --arg pbs_jobid "${PBS_JOBID}" \
-    --arg mode "${PROT_MODE}" \
-    --arg repository "${REPOSITORY}" \
-    --arg branch "${BRANCH}" \
-    --arg input "${SAMPLESHEET}" \
-    --arg outdir "${OUT_DIR}" \
-    --arg nf_config "${NF_CONFIG}" \
-    --arg args "${ARGS}" \
-    '{date: $date, user: $user, node: $node, pbs_jobid: $pbs_jobid, mode: $mode, repository: $repository, branch: $branch, input: $input, outdir: $outdir, nf_config: $nf_config, args: $args}' > "${METRICS_LOG_PATH}/$(date +%Y-%m-%dT%H:%M:%SZ%z)-$(whoami)-${PBS_JOBID%.*}.json"
+  if ! mkdir -p "${METRICS_LOG_PATH}" || ! jq -n \
+      --arg date "$(date +%Y-%m-%dT%H:%M:%SZ%z)" \
+      --arg user "$(whoami)" \
+      --arg node "$(hostname)" \
+      --arg pbs_jobid "${PBS_JOBID}" \
+      --arg mode "${PROT_MODE}" \
+      --arg repository "${REPOSITORY}" \
+      --arg branch "${BRANCH}" \
+      --arg input "${SAMPLESHEET}" \
+      --arg outdir "${OUT_DIR}" \
+      --arg nf_config "${NF_CONFIG}" \
+      --arg args "${ARGS}" \
+      '{date: $date, user: $user, node: $node, pbs_jobid: $pbs_jobid, mode: $mode, repository: $repository, branch: $branch, input: $input, outdir: $outdir, nf_config: $nf_config, args: $args}' > "${METRICS_LOG_PATH}/$(date +%Y-%m-%dT%H:%M:%SZ%z)-$(whoami)-${PBS_JOBID%.*}.json"; then
+    echo "Warning: unable to write metrics log to ${METRICS_LOG_PATH}; continuing without metrics." >&2
+  fi
 
 fi
 


### PR DESCRIPTION
This change adds visibility into what modes users run and what inputs are passed in.

The functionality is enabled by default but can be disabled by setting the `ENABLE_METRICS` environment variable to `false`. 

A single JSON file is created per run, and is saved to `/srv/scratch/sbf-pipelines/metrics/${YEAR}/${MONTH}/${DATE_TIME_ISO}-${USER}-${JOB_ID}.json`. Example: `/srv/scratch/sbf-pipelines/metrics/2026/06/2026-06-05T16:23:08Z+1000-z3545907-8206526.kman.restech.unsw.edu.json`

A new file is created per run to avoid issues arising in the very small chance that two users write to the same metrics file at the same time. Organising the data by year/month also makes collection of the metrics easier.

I plan to modify my Discworld `generate-metrics` script to a generate monthly statistics for Protinfold.